### PR TITLE
Bugfix: 4x ...Tab/libs/WorldMapTabsLib-1.0-2/WorldMapTabsLib-1.0.lua:…

### DIFF
--- a/libs/WorldMapTabsLib-1.0/WorldMapTabsLib-1.0.lua
+++ b/libs/WorldMapTabsLib-1.0/WorldMapTabsLib-1.0.lua
@@ -68,6 +68,27 @@ end
 -- Local Functions
 ----------------------
 local MAX_TABS_PER_COLUMN = 8;
+local function SafeSetPoint(tab, anchor, point, relPoint, x, y)
+	if not tab or not tab.SetPoint then return end
+	-- Avoid self/loop anchors: if the target is the same tab or anchored to this tab, use a stable anchor
+	if anchor == tab or anchor == nil then
+		anchor = (QuestMapFrame and (QuestMapFrame.MapLegendTab or QuestMapFrame.QuestsTab)) or UIParent
+	end
+	if anchor and anchor.GetPoint then
+		for i = 1, anchor:GetNumPoints() do
+			local _, rel = anchor:GetPoint(i)
+			if rel == tab then
+				anchor = (QuestMapFrame and (QuestMapFrame.MapLegendTab or QuestMapFrame.QuestsTab)) or UIParent
+				break
+			end
+		end
+	end
+	if anchor == tab or anchor == nil then
+		anchor = (QuestMapFrame and (QuestMapFrame.MapLegendTab or QuestMapFrame.QuestsTab)) or UIParent
+	end
+	tab:ClearAllPoints()
+	tab:SetPoint(point or "TOPLEFT", anchor, relPoint or "TOPLEFT", x or 0, y or 0)
+end
 
 local function PlaceTabs()
 	if (#lib.tabs == 0) then return; end
@@ -94,9 +115,9 @@ local function PlaceTabs()
 				else
 					anchorTab = shownTabs[numShown - MAX_TABS_PER_COLUMN];
 				end
-				tab:SetPoint("TOPLEFT", anchorTab, "TOPRIGHT", 0, 0);
+				SafeSetPoint(tab, anchorTab, "TOPLEFT", "TOPRIGHT", 0, 0);
 			else
-				tab:SetPoint("TOPLEFT", anchorTab, "BOTTOMLEFT", 0, -3);
+				SafeSetPoint(tab, anchorTab, "TOPLEFT", "BOTTOMLEFT", 0, -3);
 			end
 			tinsert(shownTabs, tab);
 		end


### PR DESCRIPTION
When using WorldQuestTab with another addon that adds a button to QuestMapFrame.TabButtons, it will call a anchor loop as there is no guarding against it in WorldMapTabsLib.
Example:
```
if QuestMapFrame.TabButtons then
	local present = false
	for _, b in ipairs(QuestMapFrame.TabButtons) do
		if b == tabButton then
			present = true
			break
		end
	end
	if not present then table.insert(QuestMapFrame.TabButtons, tabButton) end
end
```
Will produce loaded with WorldMapTabsLib:
```
4x ...Tab/libs/WorldMapTabsLib-1.0-2/WorldMapTabsLib-1.0.lua:99: Action[SetPoint] failed because[Cannot anchor to a region dependent on it]: attempted from: WQT_QuestMapTab:SetPoint.
Relative: [EQOLWorldMapDungeonPortalsTab UIParent, WorldMapFrame.QuestLog, EQOLWorldMapDungeonPortalsTab]
Dependent: [EQOLWorldMapDungeonPortalsTab UIParent, WorldMapFrame.QuestLog, EQOLWorldMapDungeonPortalsTab]
[WorldQuestTab/libs/WorldMapTabsLib-1.0-2/WorldMapTabsLib-1.0.lua]:99: in function <...Tab/libs/WorldMapTabsLib-1.0/WorldMapTabsLib-1.0.lua:72>
[WorldQuestTab/libs/WorldMapTabsLib-1.0-2/WorldMapTabsLib-1.0.lua]:115: in function <...Tab/libs/WorldMapTabsLib-1.0/WorldMapTabsLib-1.0.lua:114>
[C]: in function 'Show'
[Blizzard_UIParentPanelManager/Shared/UIParentPanelManager.lua]:436: in function 'SetUIPanel'
[Blizzard_UIParentPanelManager/Shared/UIParentPanelManager.lua]:279: in function 'ShowUIPanel'
[Blizzard_UIParentPanelManager/Shared/UIParentPanelManager.lua]:108: in function <...UIParentPanelManager/Shared/UIParentPanelManager.lua:103>
[C]: in function 'SetAttribute'
[Blizzard_UIParentPanelManager/Shared/UIParentPanelManager.lua]:825: in function 'ShowUIPanel'
[Blizzard_WorldMap/QuestLogOwnerMixin.lua]:115: in function 'SetDisplayState'
[Blizzard_WorldMap/QuestLogOwnerMixin.lua]:51: in function <...faceBlizzard_WorldMap/QuestLogOwnerMixin.lua:23>
[C]: in function 'HandleUserActionToggleSelf'
[Blizzard_WorldMap/Blizzard_WorldMap.lua]:567: in function 'ToggleWorldMap'
[TOGGLEWORLDMAP]:1: in function <[string "TOGGLEWORLDMAP"]:1>

Locals:
shownTabs = <table> {
 1 = Frame {
 }
 2 = Frame {
 }
 3 = Frame {
 }
 4 = EQOLWorldMapDungeonPortalsTab {
 }
}
(for state) = <table> {
 1 = WQT_QuestMapTab {
 }
}
(for control) = 1
k = 1
tab = WQT_QuestMapTab {
 activeAtlas = "Worldquest-icon"
 inactiveAtlas = "Worldquest-icon"
 SelectedTexture = Texture {
 }
 tooltipText = "World Quests"
 displayMode = 100
 Background = Texture {
 }
 Icon = Texture {
 }
}
numShown = 4
column = 0
row = 4
anchorTab = EQOLWorldMapDungeonPortalsTab {
 SelectedTexture = Texture {
 }
 tooltipText = "Teleport Compendium"
 CustomIcon = Texture {
 }
 Background = Texture {
 }
 Icon = Texture {
 }
 activeAtlas = "questlog-tab-icon-maplegend"
 inactiveAtlas = "questlog-tab-icon-maplegend-inactive"
 _eqolStateHooks = true
 displayMode = "EQOL_DungeonPortals"
 _eqolPendingVisible = true
}
lib = <table> {
 contentFrames = <table> {
 }
 tabs = <table> {
 }
}
MAX_TABS_PER_COLUMN = 8
```

The new code does the following:
- If a tab or tab:SetPoint is missing, it returns.
- It prevents self/loop anchors:
  - If the chosen anchor is the same as the tab or nil, it switches to a safe fallback (MapLegend tab, or Quests tab, or UIParent).
  - It also checks the anchor’s current points; if any of those points are already anchored to tab, it treats this as a loop and falls back
        to the safe anchor.
- After selecting a safe anchor, it clears the tab’s points and calls SetPoint with the requested parameters.

I hope it's okay to give a pullrequest to you, otherwise I would appreciate if you could guard/harden your code please.

My addon which has the problem with it: https://www.curseforge.com/wow/addons/eqol