### PR TITLE
Update library reference for WorldMapTabs

### DIFF
--- a/WorldQuestTab.lua
+++ b/WorldQuestTab.lua
@@ -891,7 +891,7 @@ function WQT:OnEnable()
 	
 	-- Show default tab depending on setting
 	if (self.settings.general.defaultTab) then
-		local tabLib = LibStub("WorldMapTabsLib-1.0");
+		local tabLib = LibStub("LibWorldMapTabs");
 		tabLib:SetDisplayMode(WQT_QuestMapTab.displayMode);
 	end
 	WQT_WorldQuestFrame.tabBeforeAnchor = WQT_WorldQuestFrame.selectedTab;


### PR DESCRIPTION
Was receiving a library reference error after yesterday's https://github.com/LanceDH/WorldQuestTab/releases/tag/11.2.12. This seemed to fix the error for me.